### PR TITLE
log-server: clean before build

### DIFF
--- a/packages/log-server/package.json
+++ b/packages/log-server/package.json
@@ -20,7 +20,7 @@
     "log-server": "./dist/cli.js"
   },
   "scripts": {
-    "build": "tsc -b tsconfig.build.json",
+    "build": "tsc -b tsconfig.build.json --clean && tsc -b tsconfig.build.json",
     "prepublish": "pnpm run build",
     "cli": "tsx ./src/cli.ts",
     "cli-watch": "tsx --watch ./src/cli.ts"


### PR DESCRIPTION
Because extra files in the mutation folder would mess up the mutation, it is important to cleanup before building