### PR TITLE
log-server: fix batch log's date and order

### DIFF
--- a/.changeset/late-emus-fold.md
+++ b/.changeset/late-emus-fold.md
@@ -1,0 +1,5 @@
+---
+'@lightmill/log-server': major
+---
+
+Fix bach log's date and ordering. Requires db migration.

--- a/packages/log-server/src/db-migrations/2023-02-23-batch-order.ts
+++ b/packages/log-server/src/db-migrations/2023-02-23-batch-order.ts
@@ -1,0 +1,47 @@
+import { Kysely } from 'kysely';
+
+export async function up(
+  db: Kysely<{ log: { clientDate: Date; createdAt?: Date } }>
+) {
+  await db.transaction().execute(async (trx) => {
+    await trx.schema
+      .alterTable('log')
+      .addColumn('batchOrder', 'integer')
+      .execute();
+
+    await trx.schema.dropIndex('logSort').execute();
+
+    await trx.schema
+      .createIndex('logSort')
+      .on('log')
+      .columns([
+        'experimentId',
+        'runId',
+        'type',
+        'clientDate',
+        'createdAt',
+        'batchOrder',
+      ])
+      .execute();
+  });
+}
+
+export async function down(db: Kysely<unknown>) {
+  await db.transaction().execute(async (trx) => {
+    await trx.schema.dropIndex('logSort').execute();
+    await trx.schema.alterTable('log').dropColumn('batchOrder').execute();
+    // Put back the old index.
+    await trx.schema
+      .createIndex('logSort')
+      .on('log')
+      .columns([
+        'experimentId',
+        'runId',
+        'type',
+        'clientDate',
+        'createdAt',
+        'logId',
+      ])
+      .execute();
+  });
+}


### PR DESCRIPTION
Batch logs were not properly saved in the database : clientDate could be switched between logs, and resulting log order was messed up. This PR fixes this, and introduces a new database column: batchOrder,  to properly order logs that were sent in the same batch with the same date. However it does not help with logs with the same date that are sent in different batches. It is unclear in what situation this would happen.