### PR TITLE
log-server: flatten urls to prevent collisions

### DIFF
--- a/.changeset/pink-cars-sort.md
+++ b/.changeset/pink-cars-sort.md
@@ -1,0 +1,5 @@
+---
+'@lightmill/log-client': major
+---
+
+Now complies with the new log-server API.

--- a/.changeset/tidy-otters-whisper.md
+++ b/.changeset/tidy-otters-whisper.md
@@ -1,0 +1,5 @@
+---
+'@lightmill/log-server': major
+---
+
+Flatten urls to prevent collisions: post /experiments/runs -> post /runs, get /experiments/:experiment/runs/logs -> get /experiments/:experiment/logs.

--- a/packages/log-client/src/main.ts
+++ b/packages/log-client/src/main.ts
@@ -81,15 +81,15 @@ export class LogClient<InputLog extends BaseLog = AnyLog> {
       throw new Error('Run is already starting');
     }
     this.#isStarting = false;
-    let body: ApiBody<'post', '/experiments/runs'> = {
+    let body: ApiBody<'post', '/runs'> = {
       experiment: this.#experiment,
       id: this.#run,
     };
-    let url = `${this.#apiRoot}/experiments/runs`;
+    let url = `${this.#apiRoot}/runs`;
     let { links } = (await post(url, {
       body,
       credentials: 'include',
-    })) as ApiResponse<'post', '/experiments/runs'>; // We trust the server to return the correct type.
+    })) as ApiResponse<'post', '/runs'>; // We trust the server to return the correct type.
     this.#endpoints = links;
     this.#runStatus = 'running';
   }

--- a/packages/log-server/src/api.ts
+++ b/packages/log-server/src/api.ts
@@ -70,7 +70,7 @@ export const api = makeApi([
   },
   {
     method: 'post',
-    path: '/experiments/runs',
+    path: '/runs',
     parameters: [
       {
         schema: z
@@ -138,7 +138,7 @@ export const api = makeApi([
   },
   {
     method: 'get',
-    path: '/experiments/:experiment/runs/logs',
+    path: '/experiments/:experiment/logs',
     parameters: [
       {
         name: 'type',

--- a/packages/log-server/src/app.ts
+++ b/packages/log-server/src/app.ts
@@ -116,7 +116,7 @@ export function LogServer({
     res.status(200).json({ status: 'ok' });
   });
 
-  router.post('/experiments/runs', async (req, res, next) => {
+  router.post('/runs', async (req, res, next) => {
     try {
       if (req.session?.role == null) {
         req.session = { role: 'participant', runs: [] };
@@ -255,7 +255,7 @@ export function LogServer({
     },
   );
 
-  router.get('/experiments/:experiment/runs/logs', async (req, res, next) => {
+  router.get('/experiments/:experiment/logs', async (req, res, next) => {
     try {
       if (req.session?.role !== 'admin') {
         res.status(403).json({


### PR DESCRIPTION
post /experiments/runs is now post /runs
get /experiments/:experiment/runs/logs is now get /experiments/:experiment/logs