### PR TITLE
log-server: drop run_status from log CSV export

### DIFF
--- a/.changeset/three-pandas-wink.md
+++ b/.changeset/three-pandas-wink.md
@@ -1,0 +1,5 @@
+---
+'@lightmill/log-server': major
+---
+
+Drop run_status column from CSV export. This column is not usually needed when fetching an experiment's results, and adds noise.

--- a/packages/log-server/__tests__/__snapshots__/app-logs.test.ts.snap
+++ b/packages/log-server/__tests__/__snapshots__/app-logs.test.ts.snap
@@ -206,9 +206,9 @@ exports[`LogServer: get /logs > returns logs as csv by default 1`] = `
 `;
 
 exports[`LogServer: get /logs > returns logs as csv by default 2`] = `
-"type,experiment_name,run_name,run_status,mock_col_1,mock_col_2,mock_col_3
-getLogs:type-1,getLogs:experimentName-1,getLogs:runName-1,running,log1-mock-value1,log1-mock-value2,
-getLogs:type-2,getLogs:experimentName-2,getLogs:runName-2,completed,log2-mock-value1,log2-mock-value2,log2-mock-value3
+"type,experiment_name,run_name,mock_col_1,mock_col_2,mock_col_3
+getLogs:type-1,getLogs:experimentName-1,getLogs:runName-1,log1-mock-value1,log1-mock-value2,
+getLogs:type-2,getLogs:experimentName-2,getLogs:runName-2,log2-mock-value1,log2-mock-value2,log2-mock-value3
 "
 `;
 
@@ -226,9 +226,9 @@ exports[`LogServer: get /logs > returns logs as csv if csv is the first supporte
 `;
 
 exports[`LogServer: get /logs > returns logs as csv if csv is the first supported format in the Accept header 2`] = `
-"type,experiment_name,run_name,run_status,mock_col_1,mock_col_2,mock_col_3
-getLogs:type-1,getLogs:experimentName-1,getLogs:runName-1,running,log1-mock-value1,log1-mock-value2,
-getLogs:type-2,getLogs:experimentName-2,getLogs:runName-2,completed,log2-mock-value1,log2-mock-value2,log2-mock-value3
+"type,experiment_name,run_name,mock_col_1,mock_col_2,mock_col_3
+getLogs:type-1,getLogs:experimentName-1,getLogs:runName-1,log1-mock-value1,log1-mock-value2,
+getLogs:type-2,getLogs:experimentName-2,getLogs:runName-2,log2-mock-value1,log2-mock-value2,log2-mock-value3
 "
 `;
 

--- a/packages/log-server/src/csv-export.ts
+++ b/packages/log-server/src/csv-export.ts
@@ -4,12 +4,7 @@ import { mapKeys, pickBy, pipe } from 'remeda';
 import { type AllFilter, type Log, SQLiteStore as Store } from './store.js';
 import { withSnakeCaseProps } from './utils.js';
 
-const csvLogColumns: Array<keyof Log> = [
-  'type',
-  'experimentName',
-  'runName',
-  'runStatus',
-];
+const csvLogColumns: Array<keyof Log> = ['type', 'experimentName', 'runName'];
 const renamedLogColumns: Partial<Record<keyof Log, string>> = {};
 
 export function csvExportStream(


### PR DESCRIPTION
This column may still be useful if user is unsure of run statuses. Since we don't currently expose an admin interface, it may be best to defer this PR for now.