### PR TITLE
log-server: fix DataStore#getMissingLogs

### DIFF
--- a/.changeset/shiny-views-sing.md
+++ b/.changeset/shiny-views-sing.md
@@ -1,0 +1,5 @@
+---
+'@lightmill/log-server': patch
+---
+
+Fix DataStore#getMissingLogs returning canceled logs.

--- a/packages/log-server/src/data-store.ts
+++ b/packages/log-server/src/data-store.ts
@@ -154,7 +154,7 @@ export interface DataStore {
   addLogs(
     runId: RunId,
     logs: Array<{ type: string; number: number; values: JsonObject }>,
-  ): Promise<{ logId: LogId }[]>;
+  ): Promise<Array<{ logId: LogId }>>;
 
   /**
    * Gets all unique log value property names that match the filter


### PR DESCRIPTION
In some conditions, getMissingLogs used to return canceled logs.